### PR TITLE
BaSP-TG-44: Standardize server response

### DIFF
--- a/src/controllers/admins.js
+++ b/src/controllers/admins.js
@@ -5,19 +5,19 @@ const getAllAdmins = async (req, res) => {
     const allAdmins = await Admin.find({});
     if (allAdmins) {
       return res.status(200).json({
-        msg: 'This is the complete list of admins',
+        message: 'This is the complete list of admins',
         data: allAdmins,
         error: false,
       });
     }
     return res.status(404).json({
-      msg: 'No list of admins found',
+      message: 'No list of admins found',
       data: undefined,
       error: true,
     });
   } catch (err) {
     return res.status(400).json({
-      msg: 'An error ocurred',
+      message: 'An error ocurred',
       data: undefined,
       error: true,
     });
@@ -36,19 +36,19 @@ const addAdmin = async (req, res) => {
     const adminSaved = await newAdmin.save();
     if (adminSaved) {
       return res.status(201).json({
-        msg: 'Admin created successfully',
+        message: 'Admin created successfully',
         data: adminSaved,
         error: false,
       });
     }
     return res.status(400).json({
-      msg: 'Admin creation failed. Please review and correct the data',
+      message: 'Admin creation failed. Please review and correct the data',
       data: undefined,
       error: true,
     });
   } catch (error) {
     return res.status(400).json({
-      msg: 'There was an error',
+      message: 'There was an error',
       data: undefined,
       error: true,
     });
@@ -64,19 +64,19 @@ const updateAdmin = async (req, res) => {
     );
     if (result) {
       return res.status(200).json({
-        msg: `Admin ${req.params.id} successfully updated`,
+        message: `Admin ${req.params.id} successfully updated`,
         data: result,
         error: false,
       });
     }
     return res.status(404).json({
-      msg: `No admin with the id of ${req.params.id}`,
+      message: `No admin with the id of ${req.params.id}`,
       data: undefined,
       error: true,
     });
   } catch (err) {
     return res.status(400).json({
-      msg: 'There was an error',
+      message: 'There was an error',
       data: undefined,
       error: true,
     });
@@ -88,19 +88,19 @@ const findAdminById = async (req, res) => {
     const result = await Admin.findById(req.params.id);
     if (result) {
       return res.status(200).json({
-        msg: `Admin ${req.params.id} found`,
+        message: `Admin ${req.params.id} found`,
         data: result,
         error: false,
       });
     }
     return res.status(404).json({
-      msg: `No admin with the id of ${req.params.id}`,
+      message: `No admin with the id of ${req.params.id}`,
       data: undefined,
       error: true,
     });
   } catch (error) {
     return res.status(400).json({
-      msg: 'There was an error',
+      message: 'There was an error',
       data: undefined,
       error: true,
     });
@@ -112,19 +112,19 @@ const delAdmin = async (req, res) => {
     const result = await Admin.findByIdAndDelete(req.params.id);
     if (result) {
       return res.status(200).json({
-        msg: `Admin ${req.params.id} deleted successfully`,
+        message: `Admin ${req.params.id} deleted successfully`,
         data: result,
         error: false,
       });
     }
     return res.status(404).json({
-      msg: `Admin ${req.params.id} not found`,
+      message: `Admin ${req.params.id} not found`,
       data: undefined,
       error: true,
     });
   } catch (err) {
     return res.status(400).json({
-      msg: 'There was an error',
+      message: 'There was an error',
       data: undefined,
       error: true,
     });

--- a/src/controllers/projects.js
+++ b/src/controllers/projects.js
@@ -4,13 +4,13 @@ export const getAllProjects = async (req, res) => {
   try {
     const findAll = await Projects.find({}).populate('employees.employeeId').populate('admin');
     return res.status(200).json({
-      msg: 'All the projects found',
+      message: 'All the projects found',
       data: findAll,
       error: false,
     });
   } catch (err) {
     return res.status(400).json({
-      msg: err,
+      message: err,
       error: true,
     });
   }
@@ -21,18 +21,18 @@ export const deleteById = async (req, res) => {
     const deleted = await Projects.findByIdAndDelete(req.params.id);
     if (!deleted) {
       return res.status(404).json({
-        msg: 'Project not found.',
+        message: 'Project not found.',
         data: undefined,
         error: true,
       });
     } return res.status(200).json({
-      msg: 'Project deleted.',
+      message: 'Project deleted.',
       data: deleted,
       error: false,
     });
   } catch (err) {
     return res.status(400).json({
-      msg: 'There was an error',
+      message: 'There was an error',
       data: undefined,
       error: true,
     });
@@ -46,13 +46,13 @@ export const createProject = async (req, res) => {
     });
     await newProjects.save();
     return res.status(201).json({
-      msg: 'New Project successfully created',
+      message: 'New Project successfully created',
       data: newProjects,
       error: false,
     });
   } catch (error) {
     return res.status(400).json({
-      msg: 'There was an error',
+      message: 'There was an error',
       data: error,
       error: false,
     });
@@ -68,18 +68,18 @@ export const updateProjectById = async (req, res) => {
     ).populate('employees.employeeId').populate('admin');
     if (!projectToUpdate) {
       return res.status(404).json({
-        msg: `Project not found for id: ${req.params.id}`,
+        message: `Project not found for id: ${req.params.id}`,
         error: true,
       });
     }
     return res.status(200).json({
-      msg: `Project with id ${req.params.id} has been successfully updated!`,
+      message: `Project with id ${req.params.id} has been successfully updated!`,
       data: projectToUpdate,
       error: false,
     });
   } catch (error) {
     return res.status(400).json({
-      msg: 'There was an error',
+      message: 'There was an error',
       data: error,
       error: true,
     });
@@ -93,18 +93,18 @@ export const getProjectsByStatus = async (req, res) => {
     }).populate('employees.employeeId').populate('admin');
     if (activeProjects.length) {
       return res.status(200).json({
-        msg: 'Obtained projects!',
+        message: 'Obtained projects!',
         data: activeProjects,
         error: false,
       });
     }
     return res.status(400).json({
-      msg: `Projects not found for status: ${req.params.status}`,
+      message: `Projects not found for status: ${req.params.status}`,
       error: true,
     });
   } catch (error) {
     return res.status(400).json({
-      msg: 'There was an error',
+      message: 'There was an error',
       data: error,
       error: true,
     });
@@ -116,18 +116,18 @@ export const getProjectById = async (req, res) => {
     const wantedProject = await Projects.findById(req.params.id).populate('employees.employeeId').populate('admin');
     if (wantedProject) {
       return res.status(200).json({
-        msg: 'Successful search!',
+        message: 'Successful search!',
         data: wantedProject,
         error: false,
       });
     }
     return res.status(400).json({
-      msg: `Project not found for id: ${req.params.id}`,
+      message: `Project not found for id: ${req.params.id}`,
       error: true,
     });
   } catch (error) {
     return res.status(400).json({
-      msg: 'There was an error',
+      message: 'There was an error',
       data: error,
       error: true,
     });

--- a/src/controllers/super-admins.js
+++ b/src/controllers/super-admins.js
@@ -11,13 +11,13 @@ const createSuperAdmin = async (req, res) => {
     });
     const result = await superAdminCreate.save();
     return res.status(201).json({
-      msg: 'Request Successful',
+      message: 'New Super Admin created',
       data: result,
       error: false,
     });
   } catch (err) {
     return res.status(400).json({
-      msg: 'There was an error',
+      message: 'There was an error',
       data: err,
       error: true,
     });
@@ -33,19 +33,19 @@ const updateSuperAdmin = async (req, res) => {
     );
     if (!result) {
       return res.status(404).json({
-        msg: 'The Super Admin has not been found',
+        message: 'The Super Admin has not been found',
         data: result,
         error: true,
       });
     }
     return res.status(200).json({
-      msg: 'Request Successful',
+      message: 'Super Admin  updated',
       data: result,
       error: false,
     });
   } catch (err) {
     return res.status(400).json({
-      msg: 'There was an error',
+      message: 'There was an error',
       data: err,
       error: true,
     });
@@ -58,19 +58,19 @@ const findSuperAdminById = async (req, res) => {
     const result = await ModelSuperAdmin.findById(id);
     if (!result) {
       return res.status(404).json({
-        msg: 'The Super Admin has not been found',
+        message: 'The Super Admin has not been found',
         data: result,
         error: true,
       });
     }
     return res.status(200).json({
-      msg: 'Request Successful',
+      message: 'Request Successful',
       data: result,
       error: false,
     });
   } catch (err) {
     return res.status(400).json({
-      msg: 'There was an error',
+      message: 'There was an error',
       data: err,
       error: true,
     });
@@ -82,19 +82,19 @@ const deleteSuperAdmin = async (req, res) => {
     const result = await ModelSuperAdmin.findByIdAndDelete(req.params.id);
     if (!result) {
       return res.status(404).json({
-        msg: 'The Super Admin has not been found',
+        message: 'The Super Admin has not been found',
         data: result,
         error: true,
       });
     }
     return res.status(200).json({
-      msg: 'Request Successful',
+      message: 'Super Admin  deleted',
       data: result,
       error: false,
     });
   } catch (err) {
     return res.status(400).json({
-      msg: 'There was an error',
+      message: 'There was an error',
       data: err,
       error: true,
     });
@@ -105,13 +105,13 @@ const getSuperAdminByFilter = async (req, res) => {
   try {
     const allSuperAdmin = await ModelSuperAdmin.find(req.query);
     return res.status(200).json({
-      msg: 'Request Successful',
+      message: 'Request Successful',
       data: allSuperAdmin,
       error: false,
     });
   } catch (err) {
     return res.status(400).json({
-      msg: 'There was an error',
+      message: 'There was an error',
       data: err,
       error: true,
     });

--- a/src/controllers/time-sheets.js
+++ b/src/controllers/time-sheets.js
@@ -58,7 +58,7 @@ export const deleteTimeSheets = async (req, res) => {
       });
     }
     return res.status(200).json({
-      msg: 'Timesheet successfully deleted',
+      message: 'Timesheet successfully deleted',
       data: result,
       error: false,
     });

--- a/src/test/admins.test.js
+++ b/src/test/admins.test.js
@@ -24,7 +24,7 @@ describe('/GET /admins', () => {
 
   test('response should return an admin with the requested ID', async () => {
     const response = await request(app).get(`/admins/${adminId}`).send();
-    expect(response.body.msg).toBe('Admin 628cf22111b8397990200a06 found');
+    expect(response.body.message).toBe('Admin 628cf22111b8397990200a06 found');
   });
 });
 
@@ -39,7 +39,7 @@ describe('/POST /admins', () => {
     });
     expect(response.status).toBe(201);
     expect(response.body.error).toBe(false);
-    expect(response.body.msg).toEqual('Admin created successfully');
+    expect(response.body.message).toEqual('Admin created successfully');
     expect(response.body.data.firstName).toEqual('Regina');
     expect(response.body.data.lastName).toEqual('Phalange');
     expect(response.body.data.email).toEqual('rphalange@friends.com');
@@ -65,7 +65,7 @@ describe('/PUT /admins', () => {
       isActive: true,
     });
     expect(response.status).toBe(400);
-    expect(response.body.msg).toEqual('There was an error');
+    expect(response.body.message).toEqual('There was an error');
   });
 });
 
@@ -73,13 +73,13 @@ describe('/DELETE /admins', () => {
   test('Delete admin should return status 200', async () => {
     const response = await request(app).delete(`/admins/${adminId}`).send();
     expect(response.status).toBe(200);
-    expect(response.body.msg).toEqual(`Admin ${adminId} deleted successfully`);
+    expect(response.body.message).toEqual(`Admin ${adminId} deleted successfully`);
   });
 
   test('Delete invalid Admin ID, should return Admin not found', async () => {
     const response = await request(app).delete(`/admins/${wrongID}`);
     expect(response.status).toBe(404);
     expect(response.body.error).toBe(true);
-    expect(response.body.msg).toEqual(`Admin ${wrongID} not found`);
+    expect(response.body.message).toEqual(`Admin ${wrongID} not found`);
   });
 });

--- a/src/test/projects.test.js
+++ b/src/test/projects.test.js
@@ -23,7 +23,7 @@ describe('/GET /projects', () => {
     const response = await request(app).get('/projects').send();
     expect(response.status).toBe(200);
     expect(response.body.error).toBe(false);
-    expect(response.body.msg).toEqual('All the projects found');
+    expect(response.body.message).toEqual('All the projects found');
   });
 
   test('Check that it is not null', async () => {
@@ -53,13 +53,13 @@ describe('/POST /projects', () => {
     });
     expect(response.status).toBe(201);
     expect(response.body.error).toBe(false);
-    expect(response.body.msg).toEqual('New Project successfully created');
+    expect(response.body.message).toEqual('New Project successfully created');
   });
 
   test('Check that have an error', async () => {
     const response = await request(app).post('/projects').send();
     expect(response.status).toBe(400);
-    expect(response.body.msg).toEqual('Error during validation, check all the parameters');
+    expect(response.body.message).toEqual('Error during validation, check all the parameters');
     expect(response.body.error).toBe(true);
   });
 
@@ -113,7 +113,7 @@ describe('/POST /projects', () => {
       ],
     });
     expect(response.status).toBe(400);
-    expect(response.body.msg).toEqual('Error during validation, check all the parameters');
+    expect(response.body.message).toEqual('Error during validation, check all the parameters');
     expect(response.body.error).toBe(true);
   });
 });
@@ -121,7 +121,7 @@ describe('/POST /projects', () => {
 describe('/GET /projects/:id', () => {
   test('Response should return one project', async () => {
     const response = await request(app).get(`/projects/${projectID}`).send();
-    expect(response.body.msg).toEqual('Successful search!');
+    expect(response.body.message).toEqual('Successful search!');
     expect(response.status).toBe(200);
     expect(response.body.error).toBeFalsy();
     expect(response.body.data._id).toEqual(projectID);
@@ -130,7 +130,7 @@ describe('/GET /projects/:id', () => {
     const response = await request(app).get(`/projects/${wrongPath}`).send();
     expect(response.status).toBe(400);
     expect(response.body.error).toBe(true);
-    expect(response.body.msg).toEqual('There was an error');
+    expect(response.body.message).toEqual('There was an error');
   });
 });
 
@@ -141,7 +141,7 @@ describe('/PUT /projects', () => {
       description: 'Description of project',
       isActive: true,
     });
-    expect(response.body.msg).toEqual(`Project with id ${projectID} has been successfully updated!`);
+    expect(response.body.message).toEqual(`Project with id ${projectID} has been successfully updated!`);
     expect(response.status).toBe(200);
     expect(response.body.error).toBeFalsy();
     expect(response.body.data.projectName).toEqual('Fourth Project');
@@ -156,7 +156,7 @@ describe('/PUT /projects', () => {
     });
     expect(response.status).toBe(400);
     expect(response.body.error).toBe(true);
-    expect(response.body.msg).toEqual('Error during data validation!');
+    expect(response.body.message).toEqual('Error during data validation!');
   });
   test('Wrong input data should return error', async () => {
     const response = await request(app).put(`/projects/${wrongPath}`).send({
@@ -178,7 +178,7 @@ describe('/PUT /projects', () => {
     });
     expect(response.status).toBe(400);
     expect(response.body.error).toBe(true);
-    expect(response.body.msg).toEqual('There was an error');
+    expect(response.body.message).toEqual('There was an error');
   });
   test('Wrong ID, should return not found', async () => {
     const response = await request(app).put(`/projects/${wrongID}`).send({
@@ -200,7 +200,7 @@ describe('/PUT /projects', () => {
     });
     expect(response.status).toBe(404);
     expect(response.body.error).toBe(true);
-    expect(response.body.msg).toEqual(`Project not found for id: ${wrongID}`);
+    expect(response.body.message).toEqual(`Project not found for id: ${wrongID}`);
   });
 });
 
@@ -209,18 +209,18 @@ describe('/DELETE /projects', () => {
     const response = await request(app).delete(`/projects/${projectID}`);
     expect(response.status).toBe(200);
     expect(response.body.error).toBe(false);
-    expect(response.body.msg).toEqual('Project deleted.');
+    expect(response.body.message).toEqual('Project deleted.');
   });
   test('Wrong path data, should return error', async () => {
     const response = await request(app).delete(`/projects/${wrongPath}`);
     expect(response.status).toBe(400);
     expect(response.body.error).toBe(true);
-    expect(response.body.msg).toEqual('There was an error');
+    expect(response.body.message).toEqual('There was an error');
   });
   test('Wrong ID, should return not found', async () => {
     const response = await request(app).delete(`/projects/${wrongID}`);
     expect(response.status).toBe(404);
     expect(response.body.error).toBe(true);
-    expect(response.body.msg).toEqual('Project not found.');
+    expect(response.body.message).toEqual('Project not found.');
   });
 });

--- a/src/test/super-admins.test.js
+++ b/src/test/super-admins.test.js
@@ -13,7 +13,7 @@ describe('GET /superAdmins', () => {
   test('response should return a 200 status, false error and data', async () => {
     const response = await request(app).get('/super-admin').send();
     expect(response.status).toBe(200);
-    expect(response.body.msg).toEqual('Request Successful');
+    expect(response.body.message).toEqual('Request Successful');
     expect(response.error).toBeFalsy();
   });
 });
@@ -28,7 +28,7 @@ describe('POST /superAdmins', () => {
       isActive: true,
     });
     expect(response.status).toBe(201);
-    expect(response.body.msg).toEqual('Request Successful');
+    expect(response.body.message).toEqual('Request Successful');
     expect(response.error).toBeFalsy();
     expect(response.body.data.firstName).toEqual('Vladimir');
     expect(response.body.data.lastName).toEqual('Putin');
@@ -46,7 +46,7 @@ describe('POST /superAdmins', () => {
   test('should give error firstname required', async () => {
     const response = await request(app).post('/super-admin').send();
     expect(response.status).toBe(400);
-    expect(response.body.msg).toEqual('"firstName" is required');
+    expect(response.body.message).toEqual('"firstName" is required');
     expect(response.error).toBeTruthy();
   });
 
@@ -58,7 +58,7 @@ describe('POST /superAdmins', () => {
       isActive: true,
     });
     expect(response.status).toBe(400);
-    expect(response.body.msg).toEqual('"lastName" is required');
+    expect(response.body.message).toEqual('"lastName" is required');
     expect(response.error).toBeTruthy();
   });
 
@@ -71,7 +71,7 @@ describe('POST /superAdmins', () => {
       isActive: true,
     });
     expect(response.status).toBe(400);
-    expect(response.body.msg).toEqual('"firstName" length must be less than or equal to 30 characters long');
+    expect(response.body.message).toEqual('"firstName" length must be less than or equal to 30 characters long');
     expect(response.error).toBeTruthy();
   });
 
@@ -84,7 +84,7 @@ describe('POST /superAdmins', () => {
       isActive: true,
     });
     expect(response.status).toBe(400);
-    expect(response.body.msg).toEqual('"firstName" length must be at least 3 characters long');
+    expect(response.body.message).toEqual('"firstName" length must be at least 3 characters long');
     expect(response.error).toBeTruthy();
   });
 });
@@ -93,7 +93,7 @@ describe('GET /superAdmins/:id', () => {
   test('should get a super admin', async () => {
     const response = await request(app).get(`/super-admin/${superAdminId}`).send();
     expect(response.status).toBe(200);
-    expect(response.body.msg).toEqual('Request Successful');
+    expect(response.body.message).toEqual('Request Successful');
     expect(response.error).toBeFalsy();
     expect(response.body.data._id).toEqual(superAdminId);
     expect(response.body.data.firstName).toEqual('Vladimir');
@@ -106,14 +106,14 @@ describe('GET /superAdmins/:id', () => {
   test('should not get a super admin, super admin does not exist', async () => {
     const response = await request(app).get('/super-admin/628c11cd336973066ff800cb').send();
     expect(response.status).toBe(404);
-    expect(response.body.msg).toEqual('The Super Admin has not been found');
+    expect(response.body.message).toEqual('The Super Admin has not been found');
     expect(response.error).toBeTruthy();
   });
 
   test('should not get a super admin,  invalid ID', async () => {
     const response = await request(app).get('/super-admin/628c11cd336973066ff80cb').send();
     expect(response.status).toBe(400);
-    expect(response.body.msg).toEqual('There was an error');
+    expect(response.body.message).toEqual('There was an error');
     expect(response.error).toBeTruthy();
   });
 });
@@ -128,7 +128,7 @@ describe('PUT /superAdmins', () => {
       isActive: true,
     });
     expect(response.status).toBe(200);
-    expect(response.body.msg).toEqual('Request Successful');
+    expect(response.body.message).toEqual('Request Successful');
     expect(response.error).toBeFalsy();
     expect(response.body.data.firstName).toEqual('Valdemir');
     expect(response.body.data.lastName).toEqual('Rasputin');
@@ -142,7 +142,7 @@ describe('PUT /superAdmins', () => {
       firstName: 'segundo testeo',
     });
     expect(response.status).toBe(200);
-    expect(response.body.msg).toEqual('Request Successful');
+    expect(response.body.message).toEqual('Request Successful');
     expect(response.error).toBeFalsy();
     expect(response.body.data.firstName).toEqual('segundo testeo');
   });
@@ -152,7 +152,7 @@ describe('PUT /superAdmins', () => {
       lastName: 'apellido nuevo',
     });
     expect(response.status).toBe(200);
-    expect(response.body.msg).toEqual('Request Successful');
+    expect(response.body.message).toEqual('Request Successful');
     expect(response.error).toBeFalsy();
     expect(response.body.data.lastName).toEqual('apellido nuevo');
   });
@@ -166,14 +166,14 @@ describe('PUT /superAdmins', () => {
       isActive: true,
     });
     expect(response.status).toBe(404);
-    expect(response.body.msg).toEqual('The Super Admin has not been found');
+    expect(response.body.message).toEqual('The Super Admin has not been found');
     expect(response.error).toBeTruthy();
   });
 
   test('should not update an super admin, empty request', async () => {
     const response = await request(app).put('/super-admin').send();
     expect(response.status).toBe(404);
-    expect(response.body.msg).toEqual(undefined);
+    expect(response.body.message).toEqual(undefined);
     expect(response.error).toBeTruthy();
   });
 
@@ -182,7 +182,7 @@ describe('PUT /superAdmins', () => {
       firstName: '78948564968',
     });
     expect(response.status).toBe(200);
-    expect(response.body.msg).toEqual('Request Successful');
+    expect(response.body.message).toEqual('Request Successful');
     expect(response.error).toBeFalsy();
   });
 });
@@ -191,21 +191,21 @@ describe('DELETE /superAdmins/:id', () => {
   test('response should return a 400 status, id wrongly typed', async () => {
     const response = await request(app).delete('/super-admin/628c11cd336973066ff80cb').send();
     expect(response.status).toEqual(400);
-    expect(response.body.msg).toEqual('There was an error');
+    expect(response.body.message).toEqual('There was an error');
     expect(response.error).toBeTruthy();
   });
 
   test('response should return a 404 status, id does not exist', async () => {
     const response = await request(app).delete('/super-admin/628c11cd336973066ff800cb').send();
     expect(response.status).toEqual(404);
-    expect(response.body.msg).toEqual('The Super Admin has not been found');
+    expect(response.body.message).toEqual('The Super Admin has not been found');
     expect(response.error).toBeTruthy();
   });
 
   test('response should return a 200 status', async () => {
     const response = await request(app).delete(`/super-admin/${superAdminId}`).send();
     expect(response.status).toEqual(200);
-    expect(response.body.msg).toEqual('Request Successful');
+    expect(response.body.message).toEqual('Request Successful');
     expect(response.error).toBeFalsy();
   });
 });

--- a/src/test/super-admins.test.js
+++ b/src/test/super-admins.test.js
@@ -28,7 +28,7 @@ describe('POST /superAdmins', () => {
       isActive: true,
     });
     expect(response.status).toBe(201);
-    expect(response.body.message).toEqual('Request Successful');
+    expect(response.body.message).toEqual('New Super Admin created');
     expect(response.error).toBeFalsy();
     expect(response.body.data.firstName).toEqual('Vladimir');
     expect(response.body.data.lastName).toEqual('Putin');
@@ -128,7 +128,7 @@ describe('PUT /superAdmins', () => {
       isActive: true,
     });
     expect(response.status).toBe(200);
-    expect(response.body.message).toEqual('Request Successful');
+    expect(response.body.message).toEqual('Super Admin  updated');
     expect(response.error).toBeFalsy();
     expect(response.body.data.firstName).toEqual('Valdemir');
     expect(response.body.data.lastName).toEqual('Rasputin');
@@ -142,7 +142,7 @@ describe('PUT /superAdmins', () => {
       firstName: 'segundo testeo',
     });
     expect(response.status).toBe(200);
-    expect(response.body.message).toEqual('Request Successful');
+    expect(response.body.message).toEqual('Super Admin  updated');
     expect(response.error).toBeFalsy();
     expect(response.body.data.firstName).toEqual('segundo testeo');
   });
@@ -152,7 +152,7 @@ describe('PUT /superAdmins', () => {
       lastName: 'apellido nuevo',
     });
     expect(response.status).toBe(200);
-    expect(response.body.message).toEqual('Request Successful');
+    expect(response.body.message).toEqual('Super Admin  updated');
     expect(response.error).toBeFalsy();
     expect(response.body.data.lastName).toEqual('apellido nuevo');
   });
@@ -182,7 +182,7 @@ describe('PUT /superAdmins', () => {
       firstName: '78948564968',
     });
     expect(response.status).toBe(200);
-    expect(response.body.message).toEqual('Request Successful');
+    expect(response.body.message).toEqual('Super Admin  updated');
     expect(response.error).toBeFalsy();
   });
 });
@@ -205,7 +205,7 @@ describe('DELETE /superAdmins/:id', () => {
   test('response should return a 200 status', async () => {
     const response = await request(app).delete(`/super-admin/${superAdminId}`).send();
     expect(response.status).toEqual(200);
-    expect(response.body.message).toEqual('Request Successful');
+    expect(response.body.message).toEqual('Super Admin  deleted');
     expect(response.error).toBeFalsy();
   });
 });

--- a/src/test/tasks.test.js
+++ b/src/test/tasks.test.js
@@ -15,7 +15,7 @@ beforeAll(async () => {
 });
 
 describe('/GET /tasks', () => {
-  test('Return a 200 status, a false error and a success msg if the get method worked ok', async () => {
+  test('Return a 200 status, a false error and a success message if the get method worked ok', async () => {
     const response = await request(app).get('/tasks').send();
     expect(response.status).toBe(200);
     expect(response.error).toBeFalsy();
@@ -25,7 +25,7 @@ describe('/GET /tasks', () => {
 
 describe('/GET /tasks/:id', () => {
   const idTest = '6288fa66a52cdee44fee0144';
-  test('Return a 200 status, a false error and a success msg if the getById method worked ok', async () => {
+  test('Return a 200 status, a false error and a success message if the getById method worked ok', async () => {
     const response = await request(app).get(`/tasks/${idTest}`).send();
     expect(response.status).toBe(200);
     expect(response.error).toBeFalsy();
@@ -35,7 +35,7 @@ describe('/GET /tasks/:id', () => {
     const response = await request(app).get(`/tasks/${idTest}`).send();
     expect(response.body.data).toHaveProperty('_id', idTest);
   });
-  test('If ID is invalid then response should return a 404 status and a correct unsuccessful msg', async () => {
+  test('If ID is invalid then response should return a 404 status and a correct unsuccessful message', async () => {
     const response = await request(app).get('/tasks/6288fa66a52cdee44fee0244').send();
     expect(response.status).toBe(404);
     expect(response.body.message).toEqual("Id: 6288fa66a52cdee44fee0244 doesn't exist.");
@@ -121,7 +121,7 @@ describe('/PUT /tasks/:id', () => {
     expect(response.body.data.done).not.toBeTruthy();
     expect(response.body.data.date).toEqual('2021-10-08T03:00:00.000Z');
   });
-  test('If ID is invalid then response should return a 400 status and a correct unsuccessful msg', async () => {
+  test('If ID is invalid then response should return a 400 status and a correct unsuccessful message', async () => {
     const response = await request(app).put('/tasks/6288fa66a52cdee44fee0244').send();
     expect(response.status).toBe(400);
     expect(response.body.message).toEqual("Id: 6288fa66a52cdee44fee0244 doesn't exist.");
@@ -148,7 +148,7 @@ describe('/DELETE /tasks/:id', () => {
     expect(response.status).toBe(200);
     expect(response.body.message).toEqual('Task Deleted');
   });
-  test('If ID is invalid then response should return a 404 status and a correct unsuccessful msg', async () => {
+  test('If ID is invalid then response should return a 404 status and a correct unsuccessful message', async () => {
     const response = await request(app).delete('/tasks/6288fa66a52cdee44fee0244').send();
     expect(response.status).toBe(404);
     expect(response.body.message).toEqual('Task with id: 6288fa66a52cdee44fee0244 not found');

--- a/src/test/time-sheets.test.js
+++ b/src/test/time-sheets.test.js
@@ -187,7 +187,7 @@ describe('DELETE /timesheets/:id', () => {
   test('Response should return a status 200', async () => {
     const response = await request(app).delete(idTest).send();
     expect(response.status).toBe(200);
-    expect(response.body.msg).toEqual('Timesheet successfully deleted');
+    expect(response.body.message).toEqual('Timesheet successfully deleted');
   });
   test('Response should return a status 400', async () => {
     const response = await request(app).delete('/timesheets/wrong-endpoint').send();

--- a/src/validations/admins.js
+++ b/src/validations/admins.js
@@ -11,7 +11,7 @@ const createAdminValidation = (req, res, next) => {
   const valid = newAdmin.validate(req.body);
   if (valid.error) {
     return res.status(400).json({
-      msg: valid.error.details[0].message,
+      message: valid.error.details[0].message,
       data: undefined,
       error: true,
     });
@@ -30,7 +30,7 @@ const updateAdminValidation = (req, res, next) => {
   const valid = updateAdmin.validate(req.body);
   if (valid.error) {
     return res.status(400).json({
-      msg: valid.error.details[0].message,
+      message: valid.error.details[0].message,
       data: undefined,
       error: true,
     });

--- a/src/validations/projects.js
+++ b/src/validations/projects.js
@@ -22,7 +22,7 @@ const createProjectValidation = (req, res, next) => {
   const validation = projectValidation.validate(req.body);
   if (validation.error) {
     return res.status(400).json({
-      msg: 'Error during validation, check all the parameters',
+      message: 'Error during validation, check all the parameters',
       data: validation.error.details[0].message,
       error: true,
     });
@@ -49,7 +49,7 @@ const updateProjectValidation = (req, res, next) => {
   const validation = projectValidation.validate(req.body);
   if (validation.error) {
     return res.status(400).json({
-      msg: 'Error during data validation!',
+      message: 'Error during data validation!',
       data: validation.error.details[0].message,
       error: true,
     });

--- a/src/validations/super-admins.js
+++ b/src/validations/super-admins.js
@@ -11,7 +11,7 @@ const createSuperAdminValidation = (req, res, next) => {
   const valid = superAdminObj.validate(req.body);
   if (valid.error) {
     return res.status(400).json({
-      msg: valid.error.details[0].message,
+      message: valid.error.details[0].message,
       error: true,
     });
   }
@@ -29,7 +29,7 @@ const updateSuperAdminValidation = (req, res, next) => {
   const valid = superAdminObJ.validate(req.body);
   if (valid.error) {
     return res.status(400).json({
-      msg: valid.error.details[0].message,
+      message: valid.error.details[0].message,
       error: true,
     });
   }


### PR DESCRIPTION
Work done on this branch:

- "msg" property was changed  by "message" in order to avoid undefined response when creating a new entity