### PR TITLE
BaSP-TG-47: fix employee post response data

### DIFF
--- a/src/controllers/employees.js
+++ b/src/controllers/employees.js
@@ -31,7 +31,7 @@ export const createEmployee = async (req, res) => {
     await employee.save();
     return res.status(201).json({
       message: 'New Employee created',
-      data: newEmployee,
+      data: employee,
       error: false,
     });
   } catch (error) {

--- a/src/test/employees.test.js
+++ b/src/test/employees.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-escape */
 import mongoose from 'mongoose';
 import request from 'supertest';
 import app from '../index';
@@ -47,7 +48,7 @@ describe('/POST /employees', () => {
   test('It should return error by not passing body', async () => {
     const response = await request(app).post('/employees').send();
     expect(response.status).toBe(400);
-    expect(response.body.message).toEqual('Missing data');
+    expect(response.body.message).toEqual('\"firstName\" is required');
     expect(response.body.error).toBeTruthy();
   });
   test('Should return validation error joi', async () => {
@@ -61,7 +62,7 @@ describe('/POST /employees', () => {
     });
     expect(response.status).toBe(400);
     expect(response.body.error).toBeTruthy();
-    expect(response.body.message).toEqual('Missing data');
+    expect(response.body.message).toEqual('\"firstName\" must be a string');
   });
 });
 describe('GET /employees/:id', () => {
@@ -109,7 +110,7 @@ describe('PUT /employees/:id', () => {
       isActive: true,
     });
     expect(response.status).toBe(400);
-    expect(response.body.message).toBe('Missing data');
+    expect(response.body.message).toBe('\"lastName\" length must be at least 3 characters long');
   });
   test('Edit employee with an incorrect ID should return status 404.', async () => {
     const response = await request(app).put('/employees/6287c08beee9276577d53b2f').send({

--- a/src/test/projects.test.js
+++ b/src/test/projects.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-escape */
 import mongoose from 'mongoose';
 import request from 'supertest';
 import app from '../index';
@@ -59,7 +60,7 @@ describe('/POST /projects', () => {
   test('Check that have an error', async () => {
     const response = await request(app).post('/projects').send();
     expect(response.status).toBe(400);
-    expect(response.body.message).toEqual('Error during validation, check all the parameters');
+    expect(response.body.message).toEqual('\"projectName\" is required');
     expect(response.body.error).toBe(true);
   });
 
@@ -113,7 +114,7 @@ describe('/POST /projects', () => {
       ],
     });
     expect(response.status).toBe(400);
-    expect(response.body.message).toEqual('Error during validation, check all the parameters');
+    expect(response.body.message).toEqual('\"projectName\" length must be less than or equal to 20 characters long');
     expect(response.body.error).toBe(true);
   });
 });
@@ -156,7 +157,7 @@ describe('/PUT /projects', () => {
     });
     expect(response.status).toBe(400);
     expect(response.body.error).toBe(true);
-    expect(response.body.message).toEqual('Error during data validation!');
+    expect(response.body.message).toEqual('\"description\" length must be at least 10 characters long');
   });
   test('Wrong input data should return error', async () => {
     const response = await request(app).put(`/projects/${wrongPath}`).send({

--- a/src/test/time-sheets.test.js
+++ b/src/test/time-sheets.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-escape */
 import request from 'supertest';
 import mongoose from 'mongoose';
 import app from '../index';
@@ -57,7 +58,7 @@ describe('POST /timesheets', () => {
     const response = await request(app).post('/timesheets').send();
     expect(response.status).toBe(400);
     expect(response.error).toBeTruthy();
-    expect(response.body.message).toEqual('Missing data');
+    expect(response.body.message).toEqual('\"employee\" is required');
   });
   test('Create response should return a status 201 and response the same data', async () => {
     const timesheetTestSent = {
@@ -107,7 +108,7 @@ describe('POST /timesheets', () => {
         task: mongoose.Types.ObjectId('6288f73964ed6961bb7c2077'),
       },
     );
-    expect(response.body.data).toEqual('"rate" must be a number');
+    expect(response.body.message).toEqual('\"rate\" must be a number');
     expect(response.status).toBe(400);
   });
 });
@@ -179,7 +180,7 @@ describe('PUT /timesheets/:id', () => {
     );
     expect(response.status).toBe(400);
     expect(response.error).toBeTruthy();
-    expect(response.body.message).toEqual('Missing data');
+    expect(response.body.message).toEqual('\"role\" must be a string');
   });
 });
 


### PR DESCRIPTION
The data of the response was sending back the same object received in the requestas confirmation. Now it sends the object/instance created by mongoDB (on successfull POST request) which contains _id and __v